### PR TITLE
fixes al menu de combates en la clase Juego

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,5 +6,10 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/com/heroesyvillanos/Competidor.java
+++ b/src/com/heroesyvillanos/Competidor.java
@@ -31,7 +31,7 @@ public abstract class Competidor implements Comparable<Competidor> {
 		return comp_1.getPromedioCaracteristica(c) - comp_2.getPromedioCaracteristica(c);
 	}
 	
-	public int esGanador(Competidor competidor, Caracteristica c) throws Exception {
+	public int esGanador(Competidor competidor, Caracteristica c) throws Exception, NullPointerException{
 		if(this.tipoCompetidor == competidor.tipoCompetidor) {
 			throw new Exception("No se pueden enfrentar competidores del mismo tipo");
 		}

--- a/src/com/heroesyvillanos/Juego.java
+++ b/src/com/heroesyvillanos/Juego.java
@@ -608,8 +608,15 @@ public class Juego {
             System.out.println("2. Ver reglas de combate");
             System.out.println("3. Regresar al Menú Principal");
             System.out.print("Seleccione una opción: ");
-
-            int seleccion = scanner.nextInt();
+            int seleccion = 0;
+            
+            try {
+				 seleccion = scanner.nextInt();
+			} catch (Exception e) {
+				scanner.nextLine();
+				seguir = true;
+			}
+            
 
             switch (seleccion) {
                 case 1:
@@ -637,8 +644,10 @@ public class Juego {
         	Competidor comp2 = seleccionarCompetidor();
         	Caracteristica car = seleccionarCaracteristica();
         	combatir(comp1, comp2, car);
+		} catch (NullPointerException e) {
+			System.out.println("No se puede combatir con una liga vacía");
+			System.out.println("Regresando al menú de combates");
 		} catch (Exception e) {
-			// TODO: handle exception
 			System.out.println(e.getMessage());
 			System.out.println("Regresando al menú de combates");
 		}

--- a/src/com/heroesyvillanos/Liga.java
+++ b/src/com/heroesyvillanos/Liga.java
@@ -62,7 +62,7 @@ public class Liga extends Competidor implements Comparable<Competidor> {
 	}
 	
 	@Override
-	protected int getPromedioCaracteristica(Caracteristica c) {
+	protected int getPromedioCaracteristica(Caracteristica c) throws NullPointerException{
 		return cache_promedio_caracteristicas.get(c);
 	}
 	


### PR DESCRIPTION
-no se puede combatir con una liga vacia, mensaje de error 
-ingresar caracteres que no sean numeros en el menu combate da error en vez que excepcion